### PR TITLE
Validation: Fix for orgID and device

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ORGID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.commons.util.ToStringBuilder;
@@ -38,8 +39,9 @@ public class AddCommand extends Command {
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney "
-            + PREFIX_ORGID + "ORGID123 "
-            + PREFIX_DEVICEINFO + "DeviceInfoXYZ";
+            + PREFIX_ORGID + "123 "
+            + PREFIX_DEVICEINFO + "DeviceInfoXYZ"
+            + PREFIX_STATUS + "pending_approval";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person or orgID already exists in the address book";
@@ -73,11 +75,10 @@ public class AddCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof AddCommand)) {
+        if (!(other instanceof AddCommand otherAddCommand)) {
             return false;
         }
 
-        AddCommand otherAddCommand = (AddCommand) other;
         return toAdd.equals(otherAddCommand.toAdd);
     }
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -40,11 +40,11 @@ public class AddCommand extends Command {
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney "
             + PREFIX_ORGID + "123 "
-            + PREFIX_DEVICEINFO + "DeviceInfoXYZ"
+            + PREFIX_DEVICEINFO + "DeviceInfoXYZ "
             + PREFIX_STATUS + "pending_approval";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person or orgID already exists in the address book";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This orgID already exists in the address book";
 
     private final Person toAdd;
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -42,7 +42,7 @@ public class AddCommand extends Command {
             + PREFIX_DEVICEINFO + "DeviceInfoXYZ";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person or orgID already exists in the address book";
 
     private final Person toAdd;
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -57,7 +57,7 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person or orgID already exists in the address book.";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This orgID already exists in the address book.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -57,7 +57,7 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person or orgID already exists in the address book.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;

--- a/src/main/java/seedu/address/logic/commands/SetStatusCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SetStatusCommand.java
@@ -23,7 +23,7 @@ public class SetStatusCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 s/pending_approval";
 
     public static final String MESSAGE_SUCCESS = "Status successfully added";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person or orgID already has the status";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This orgID already has the status";
     private final Index index;
     private final Status newStatus;
 

--- a/src/main/java/seedu/address/logic/commands/SetStatusCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SetStatusCommand.java
@@ -23,7 +23,7 @@ public class SetStatusCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 s/pending_approval";
 
     public static final String MESSAGE_SUCCESS = "Status successfully added";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already has the status";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person or orgID already has the status";
     private final Index index;
     private final Status newStatus;
 

--- a/src/main/java/seedu/address/model/person/OrgID.java
+++ b/src/main/java/seedu/address/model/person/OrgID.java
@@ -9,14 +9,15 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class OrgID {
     public static final String MESSAGE_CONSTRAINTS = "OrgIDs should only "
-            + "contain alphanumeric characters "
+            + "be unique numeric values "
+            + ", should be less than 10 digits"
             + "and it should not be blank";
 
     /*
      * The first character of the OrgID must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}]+";
+    public static final String VALIDATION_REGEX = "\\d{1,10}";
 
     public final String value;
 
@@ -28,7 +29,7 @@ public class OrgID {
     public OrgID(String orgID) {
         requireNonNull(orgID);
         checkArgument(isValidOrgID(orgID), MESSAGE_CONSTRAINTS);
-        value = orgID;
+        value = String.format("%10s", orgID).replace(" ","0");
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/OrgID.java
+++ b/src/main/java/seedu/address/model/person/OrgID.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class OrgID {
     public static final String MESSAGE_CONSTRAINTS = "OrgIDs should only "
             + "be unique numeric values "
-            + ", should be less than 10 digits"
+            + ", should be less than 10 digits "
             + "and it should not be blank";
 
     /*

--- a/src/main/java/seedu/address/model/person/OrgID.java
+++ b/src/main/java/seedu/address/model/person/OrgID.java
@@ -29,7 +29,7 @@ public class OrgID {
     public OrgID(String orgID) {
         requireNonNull(orgID);
         checkArgument(isValidOrgID(orgID), MESSAGE_CONSTRAINTS);
-        value = String.format("%10s", orgID).replace(" ","0");
+        value = String.format("%10s", orgID).replace(" ", "0");
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -93,8 +93,7 @@ public class Person {
         }
 
         return otherPerson != null
-                && (otherPerson.getName().equals(getName())
-                || otherPerson.getOrgID().equals(getOrgID()));
+                && otherPerson.getOrgID().equals(getOrgID());
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -93,7 +93,8 @@ public class Person {
         }
 
         return otherPerson != null
-                && otherPerson.getName().equals(getName());
+                && (otherPerson.getName().equals(getName())
+                || otherPerson.getOrgID().equals(getOrgID()));
     }
 
     /**

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -4,7 +4,7 @@
     "phone": "94351253",
     "email": "alice@example.com",
     "address": "123, Jurong West Ave 6, #08-111",
-    "orgid" : "ORGID123",
+    "orgid" : "0000000123",
     "deviceinfo" : "DeviceInfoXYZ",
     "tags": [ "friends" ]
   }, {
@@ -12,7 +12,7 @@
     "phone": "94351253",
     "email": "pauline@example.com",
     "address": "4th street",
-    "orgid" : "ORGID123",
+    "orgid" : "0000000123",
     "deviceinfo" : "DeviceInfoXYZ"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -14,7 +14,7 @@
     "email": "pauline@example.com",
     "address": "4th street",
     "orgid" : "0000000123",
-    "deviceinfo" : "DeviceInfoXYZ"
+    "deviceinfo" : "DeviceInfoXYZ",
     "status" : "on_hold"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -5,7 +5,7 @@
         "phone" : "94351253",
         "email" : "alice@example.com",
         "address" : "123, Jurong West Ave 6, #08-111",
-        "orgid" : "ORG123",
+        "orgid" : "0000000123",
         "deviceinfo" : "DeviceA",
         "tags" : [ "friends" ]
     }, {
@@ -13,7 +13,7 @@
         "phone" : "98765432",
         "email" : "johnd@example.com",
         "address" : "311, Clementi Ave 2, #02-25",
-        "orgid" : "ORG124",
+        "orgid" : "0000000124",
         "deviceinfo" : "DeviceB",
         "tags" : [ "owesMoney", "friends" ]
     }, {
@@ -21,7 +21,7 @@
         "phone" : "95352563",
         "email" : "heinz@example.com",
         "address" : "wall street",
-        "orgid" : "ORG125",
+        "orgid" : "0000000125",
         "deviceinfo" : "DeviceC",
         "tags" : [ ]
     }, {
@@ -29,7 +29,7 @@
         "phone" : "87652533",
         "email" : "cornelia@example.com",
         "address" : "10th street",
-        "orgid" : "ORG126",
+        "orgid" : "0000000126",
         "deviceinfo" : "DeviceD",
         "tags" : [ "friends" ]
     }, {
@@ -37,7 +37,7 @@
         "phone" : "9482224",
         "email" : "werner@example.com",
         "address" : "michegan ave",
-        "orgid" : "ORG127",
+        "orgid" : "0000000127",
         "deviceinfo" : "DeviceE",
         "tags" : [ ]
     }, {
@@ -45,7 +45,7 @@
         "phone" : "9482427",
         "email" : "lydia@example.com",
         "address" : "little tokyo",
-        "orgid" : "ORG128",
+        "orgid" : "0000000128",
         "deviceinfo" : "DeviceF",
         "tags" : [ ]
     }, {
@@ -53,7 +53,7 @@
         "phone" : "9482442",
         "email" : "anna@example.com",
         "address" : "4th street",
-        "orgid" : "ORG129",
+        "orgid" : "0000000129",
         "deviceinfo" : "DeviceG",
         "tags" : [ ]
     }]

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -29,7 +29,6 @@ public class AddCommandIntegrationTest {
     @Test
     public void execute_newPerson_success() {
         Person validPerson = new PersonBuilder().build();
-
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.addPerson(validPerson);
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -38,8 +38,8 @@ public class CommandTestUtil {
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
-    public static final String VALID_ORGID_AMY = "ORG123";
-    public static final String VALID_ORGID_BOB = "ORG456";
+    public static final String VALID_ORGID_AMY = "0000000123";
+    public static final String VALID_ORGID_BOB = "0000000456";
     public static final String VALID_DEVICEINFO_AMY = "Device123";
     public static final String VALID_DEVICEINFO_BOB = "Device456";
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -33,7 +33,7 @@ public class AddressBookParserTest {
 
     private final AddressBookParser parser = new AddressBookParser();
 
-    @Test//
+    @Test
     public void parseCommand_add() throws Exception {
         Person person = new PersonBuilder().build();
         AddCommand command = (AddCommand) parser.parseCommand(PersonUtil.getAddCommand(person));

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ORGID_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -32,23 +33,23 @@ public class PersonTest {
         // null -> returns false
         assertFalse(ALICE.isSamePerson(null));
 
-        // same name, all other attributes different -> returns true
+        // same name, all other attributes different including orgID-> returns false
         Person editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
-                .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND).build();
-        assertTrue(ALICE.isSamePerson(editedAlice));
-
-        // different name, all other attributes same -> returns false
-        editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
+                .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND).withOrgID(VALID_ORGID_BOB).build();
         assertFalse(ALICE.isSamePerson(editedAlice));
 
-        // name differs in case, all other attributes same -> returns false
-        Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        // different name, all other attributes including orgID same -> returns true
+        editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
+        assertTrue(ALICE.isSamePerson(editedAlice));
 
-        // name has trailing spaces, all other attributes same -> returns false
+        // name differs in case, all other attributes including orgID same -> returns true
+        Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
+        assertTrue(BOB.isSamePerson(editedBob));
+
+        // name has trailing spaces, all other attributes including orgID same -> returns true
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
         editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        assertTrue(BOB.isSamePerson(editedBob));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -23,7 +23,7 @@ public class PersonBuilder {
     public static final String DEFAULT_PHONE = "85355255";
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
-    public static final String DEFAULT_ORG_ID = "ORG123";
+    public static final String DEFAULT_ORG_ID = "0000000555";
     public static final String DEFAULT_DEVICE_INFO = "Device123";
     public static final String DEFAULT_STATUS = "none";
 

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -26,7 +26,6 @@ public class TypicalPersons {
 
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
-
             .withPhone("94351253").withOrgID("0000000123").withDeviceInfo("DeviceA")
             .withTags("friends").withStatus("on_hold").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -26,42 +26,48 @@ public class TypicalPersons {
 
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
-            .withPhone("94351253").withOrgID("ORG123").withDeviceInfo("DeviceA")
+            .withPhone("94351253").withOrgID("0000000123").withDeviceInfo("DeviceA")
             .withTags("friends").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
-            .withEmail("johnd@example.com").withPhone("98765432").withOrgID("ORG124").withDeviceInfo("DeviceB")
+            .withEmail("johnd@example.com").withPhone("98765432").withOrgID("0000000124").withDeviceInfo("DeviceB")
             .withTags("owesMoney", "friends").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withEmail("heinz@example.com").withAddress("wall street").withOrgID("ORG125").withDeviceInfo("DeviceC")
+            .withEmail("heinz@example.com").withAddress("wall street").withOrgID("0000000125").withDeviceInfo("DeviceC")
             .build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
-            .withEmail("cornelia@example.com").withAddress("10th street").withOrgID("ORG126").withDeviceInfo("DeviceD")
+            .withEmail("cornelia@example.com").withAddress("10th street").withOrgID("0000000126")
+            .withDeviceInfo("DeviceD")
             .withTags("friends").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
-            .withEmail("werner@example.com").withAddress("michegan ave").withOrgID("ORG127").withDeviceInfo("DeviceE")
+            .withEmail("werner@example.com").withAddress("michegan ave").withOrgID("0000000127")
+            .withDeviceInfo("DeviceE")
             .build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
-            .withEmail("lydia@example.com").withAddress("little tokyo").withOrgID("ORG128").withDeviceInfo("DeviceF")
+            .withEmail("lydia@example.com").withAddress("little tokyo").withOrgID("0000000128")
+            .withDeviceInfo("DeviceF")
             .build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
-            .withEmail("anna@example.com").withAddress("4th street").withOrgID("ORG129").withDeviceInfo("DeviceG")
+            .withEmail("anna@example.com").withAddress("4th street").withOrgID("0000000129").withDeviceInfo("DeviceG")
             .build();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
-            .withEmail("stefan@example.com").withAddress("little india").withOrgID("ORG130").withDeviceInfo("DeviceH")
+            .withEmail("stefan@example.com").withAddress("little india").withOrgID("0000000130")
+            .withDeviceInfo("DeviceH")
             .build();
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
-            .withEmail("hans@example.com").withAddress("chicago ave").withOrgID("ORG131").withDeviceInfo("DeviceI")
+            .withEmail("hans@example.com").withAddress("chicago ave").withOrgID("0000000131").withDeviceInfo("DeviceI")
             .build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
-            .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withOrgID("ORG123").withDeviceInfo("Device123")
+            .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withOrgID("0000000123")
+            .withDeviceInfo("Device123")
             .withTags(VALID_TAG_FRIEND).build();
     public static final Person BOB = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-            .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withOrgID("ORG456").withDeviceInfo("Device456")
+            .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withOrgID("0000000456")
+            .withDeviceInfo("Device456")
             .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
             .build();
 


### PR DESCRIPTION
Added validation for orgID to only accept numeric values with less than 10 digits.
orgID of employees also need to be unique but names now dont need to be unique.
Modified error messages to reflect new requirements.

Closes #48 