### PR TITLE
Messages: Fixed errors

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -23,7 +23,7 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book.\n"
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "

--- a/src/main/java/seedu/address/logic/commands/SetStatusCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SetStatusCommand.java
@@ -19,7 +19,7 @@ public class SetStatusCommand extends Command {
     public static final String COMMAND_WORD = "set_status";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": sets the status of the person identified by the index number\n"
-            + "Parameters: INDEX (must be a positive integer), status\n"
+            + "Parameters: INDEX (must be a positive integer) s/status\n"
             + "Example: " + COMMAND_WORD + " 1 s/pending_approval";
 
     public static final String MESSAGE_SUCCESS = "Status successfully added";

--- a/src/main/java/seedu/address/model/tag/Status.java
+++ b/src/main/java/seedu/address/model/tag/Status.java
@@ -49,7 +49,7 @@ public enum Status {
      */
     @Override
     public String toString() {
-        return '[' + name().toLowerCase() + ']';
+        return name().toLowerCase();
     }
 
     /**


### PR DESCRIPTION
Fixed a bunch of messaging errors.

closes #96. Set status prefix s/ shows in the parameters
![Screenshot from 2025-03-29 18-04-23](https://github.com/user-attachments/assets/b4f0de3a-eb4b-4d7c-9e1c-c149bda9ad1a)

closes #97 Add Command error message parameters now on new line.  
![Screenshot from 2025-03-29 18-04-10](https://github.com/user-attachments/assets/d6a98b20-41b1-47f6-a7f9-4dddf9fec561)

closes #98. Add command success message status no longer boxed
![image](https://github.com/user-attachments/assets/4db29157-e21e-4916-b51b-5bc49079baad)


Closes #99, Filter command status no longer boxed aswell


