### PR TITLE
Command: CLI convention

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -31,7 +31,7 @@ AddressBook Level 3 (AB3) is a **desktop app for managing contacts, optimized fo
    * `add n/John Doe p/98765432 e/johnd@example.com a/311, Clementi Ave 2, #02-25 t/friends t/owesMoney i/123 d/DeviceInfoXYZ s/pending_approval` : Adds a contact named `John Doe` to the Address Book.
 
    * `delete 3` : Deletes the 3rd contact shown in the current list.
-   * `set_status 3 s/none` : Sets the status of the 3rd contact to `none`.
+   * `set-status 3 s/none` : Sets the status of the 3rd contact to `none`.
 
    * `clear` : Deletes all contacts.
 

--- a/src/main/java/seedu/address/logic/commands/FilterStatusCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterStatusCommand.java
@@ -9,7 +9,7 @@ import seedu.address.model.tag.Status;
  * Filters status of people on the address book.
  */
 public class FilterStatusCommand extends Command {
-    public static final String COMMAND_WORD = "filter_status";
+    public static final String COMMAND_WORD = "filter-status";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Filters persons by status.\n"
             + "Parameters: STATUS (must be one of: none, pending_approval, servicing, pending_external, on_hold)\n"

--- a/src/main/java/seedu/address/logic/commands/SetStatusCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SetStatusCommand.java
@@ -16,7 +16,7 @@ import seedu.address.model.tag.Status;
  * Sets status of a person on the address book.
  */
 public class SetStatusCommand extends Command {
-    public static final String COMMAND_WORD = "set_status";
+    public static final String COMMAND_WORD = "set-status";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": sets the status of the person identified by the index number\n"
             + "Parameters: INDEX (must be a positive integer), status\n"


### PR DESCRIPTION
Change the command keywords for `set_status` and `filter_status` to `set-status` and `filter-status` to fit CLI conventions.
I have also edited the Notion for the new User Guide to reflect the new commands. 
Closes #94 and closes #100.